### PR TITLE
REPO-1088 : Alfresco Tail log page displays multiple log lines with the same timestamp and message

### DIFF
--- a/src/main/amp/config/alfresco/enterprise/webscripts/org/alfresco/enterprise/repository/admin/support-tools/admin-log-settings-tail.get.js
+++ b/src/main/amp/config/alfresco/enterprise/webscripts/org/alfresco/enterprise/repository/admin/support-tools/admin-log-settings-tail.get.js
@@ -80,14 +80,11 @@ if (mbean == null){
 		var filteredMessages = [];
 		for each (messageline in message)
 		{
-			for each (messageline in message)
+			for each (filter in filters)
 			{
-				for each (filter in filters)
+				if (messageline.indexOf(filter) > -1)
 				{
-					if (messageline.indexOf(filter) > -1)
-					{
-						filteredMessages.push(messageline);
-					}
+					filteredMessages.push(messageline);
 				}
 			}
 		}


### PR DESCRIPTION
   - removed unneccessary for loop